### PR TITLE
Moved location by deviceId to Locations resource.

### DIFF
--- a/meerkat_api/resources/devices.py
+++ b/meerkat_api/resources/devices.py
@@ -1,21 +1,17 @@
 """
 Data resource for getting Device data
 """
+import json
 import logging
 
-from flask import current_app, jsonify
+from flask import current_app
 from flask_restful import Resource, abort
-from sqlalchemy import or_
 
-from meerkat_api.extensions import db, api
 from meerkat_abacus import model
-import json
-
 from meerkat_api.authentication import authenticate
-
+from meerkat_api.extensions import db, api
+from meerkat_api.util import rows_to_dicts
 from .. import common as c
-
-from meerkat_api.util import rows_to_dicts, row_to_dict
 
 
 class Devices(Resource):
@@ -44,32 +40,4 @@ class Devices(Resource):
             return {"message": "No devices registered"}
 
 
-class LocationByDeviceId(Resource):
-    """
-    Location by device_id
-
-    Args:\n
-        device_id: id of a device\n
-    Returns:\n
-       location: location
-    """
-
-    def get(self, device_id):
-        locations_deviceid = model.Locations.deviceid
-        location_filter = or_(locations_deviceid == device_id,
-                              locations_deviceid.startswith("{},".format(device_id)),
-                              locations_deviceid.contains(",{},".format(device_id)),
-                              locations_deviceid.endswith(",{}".format(device_id)),
-                              )
-        query = db.session.query(model.Locations).filter(location_filter)
-        if query.count() == 0:
-            abort(404, message="No location matching deviceid: {!r}".format(device_id))
-        else:
-            return jsonify(row_to_dict(
-                query.one()
-            ))
-
-
 api.add_resource(Devices, "/devices")
-# endpoint "/device/<device_id>" is deprecated
-api.add_resource(LocationByDeviceId, "/device/<device_id>/location", "/device/<device_id>")

--- a/meerkat_api/resources/locations.py
+++ b/meerkat_api/resources/locations.py
@@ -4,8 +4,8 @@ Locations resource for querying location data
 import json
 
 from flask import jsonify, g, request
-from flask_restful import Resource
-from sqlalchemy import func
+from flask_restful import Resource, abort, reqparse
+from sqlalchemy import func, or_
 
 from meerkat_abacus import model
 from meerkat_abacus.util import get_locations
@@ -18,12 +18,27 @@ class Locations(Resource):
     """
     List all Locations
 
+    Params:\n
+        deviceId: return locations for a given deviceId
+
     Returns:\n
        locations: Locations indexed by location_id
     """
+
     def get(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument('deviceId')
+        args = parser.parse_args()
+        device_id = args.get('deviceId')
+
+        location_query = db.session.query(model.Locations)
+
+        filter_conditions = []
+        if device_id:
+            filter_conditions.append(_get_by_device_id_filter(device_id))
+
         return jsonify(rows_to_dicts(
-            db.session.query(model.Locations).all(),
+            location_query.filter(*filter_conditions).all(),
             dict_id="id"
         ))
 
@@ -37,6 +52,7 @@ class Location(Resource):
     Returns:\n
        location: location
     """
+
     def get(self, location_id):
         return jsonify(row_to_dict(
             db.session.query(model.Locations).filter(
@@ -82,7 +98,7 @@ class LocationTree(Resource):
         for l in sorted(locs.keys()):
             if l >= loc and is_child(loc, l, locs):
                 if not only_case_reports or (locs[l].case_report == 1 or
-                                             not locs[l].deviceid):
+                                                 not locs[l].deviceid):
                     if is_child(l, loc, locs):
                         ret.setdefault(locs[l].parent_location, {"nodes": []})
 
@@ -123,6 +139,7 @@ class LocationTree(Resource):
                 clean(child)
                 if not (child['nodes'] or locs[child['id']].level == 'clinic'):
                     tree['nodes'].remove(child)
+
         clean(ret[loc])
 
         return jsonify(ret[loc])
@@ -136,6 +153,7 @@ class TotClinics(Resource):
     Returns:
         number of clinics
     """
+
     def get(self, location_id, clinic_type=None):
         locs = get_locations(db.session)
         children = get_children(location_id, locs)
@@ -151,7 +169,43 @@ class TotClinics(Resource):
 
         return {"total": res[0]}
 
+
+class LocationByDeviceId(Resource):
+    """
+    === Deprecated ===
+    Use Locations with "/locations?deviceId=<device_id> instead.
+    Location by device_id
+
+    Args:\n
+        device_id: id of a device\n
+    Returns:\n
+       location: location
+    """
+
+    def get(self, device_id):
+        location_filter = _get_by_device_id_filter(device_id)
+        query = db.session.query(model.Locations).filter(location_filter)
+        if query.count() == 0:
+            abort(404, message="No location matching deviceid: {!r}".format(device_id))
+        else:
+            return jsonify(row_to_dict(
+                query.one()
+            ))
+
+
+def _get_by_device_id_filter(device_id):
+    locations_deviceid = model.Locations.deviceid
+    location_filter = or_(locations_deviceid == device_id,
+                          locations_deviceid.startswith("{},".format(device_id)),
+                          locations_deviceid.contains(",{},".format(device_id)),
+                          locations_deviceid.endswith(",{}".format(device_id)),
+                          )
+    return location_filter
+
+
 api.add_resource(Locations, "/locations")
 api.add_resource(LocationTree, "/locationtree")
 api.add_resource(Location, "/location/<location_id>")
+# endpoint "/device/<device_id>" is deprecated use /locations?deviceId=<device_id> instead
+api.add_resource(LocationByDeviceId, "/device/<device_id>")
 api.add_resource(TotClinics, "/tot_clinics/<location_id>")

--- a/meerkat_api/resources/locations.py
+++ b/meerkat_api/resources/locations.py
@@ -198,8 +198,7 @@ def _get_by_device_id_filter(device_id):
     location_filter = or_(locations_deviceid == device_id,
                           locations_deviceid.startswith("{},".format(device_id)),
                           locations_deviceid.contains(",{},".format(device_id)),
-                          locations_deviceid.endswith(",{}".format(device_id)),
-                          )
+                          locations_deviceid.endswith(",{}".format(device_id)))
     return location_filter
 
 

--- a/meerkat_api/test/__init__.py
+++ b/meerkat_api/test/__init__.py
@@ -215,8 +215,7 @@ class MeerkatAPITestCase(unittest.TestCase):
                              "epi_week",
                              "geo_shapes",
                              "variables",
-                             "variable/tot_1",
-                             "device/4/location"]
+                             "variable/tot_1"]
         no_authentication_full_paths = ["/device/4"]
 
         for url in urls:

--- a/meerkat_api/test/test_locations.py
+++ b/meerkat_api/test/test_locations.py
@@ -193,20 +193,24 @@ class MeerkatAPILocationTestCase(unittest.TestCase):
 
     def test_location_by_non_existing_device_id(self):
         for id in ["42", "fake_device_id", DEVICEID_1[1:]]:
-            rv = self.app.get('/device/%s/location' % id, headers=settings.header)
-            self.assertEqual(rv.status_code, 404)
-            self.assertTrue(("No location matching deviceid: '%s'" % id) in rv.data.decode('utf-8'))
+            rv = self.app.get('locations?deviceId={}'.format(id), headers=settings.header)
+            self.assertEqual(rv.status_code, 200)
+            actual_response_json = json.loads(rv.data.decode('utf-8'))
+            empty_json = {}
+            self.assertEqual(actual_response_json, empty_json)
 
     def test_location_by_device_id(self):
         for id in DEVICE_IDS_CSV_LIST.split(','):
-            self.validate_correct_location_returned(deviceid=id, expected_loc_id=12)
+            self.validate_correct_location_returned(deviceid=id, expected_loc_id='12')
 
     def test_location_by_device_id_imei_format(self):
         for id in DEVICE_IDS_IMEI_CSV_LIST.split(','):
-            self.validate_correct_location_returned(deviceid=id, expected_loc_id=13)
+            self.validate_correct_location_returned(deviceid=id, expected_loc_id='13')
 
     def validate_correct_location_returned(self, deviceid=None, expected_loc_id=None):
-        rv = self.app.get('/device/%s/location' % deviceid, headers=settings.header)
+        rv = self.app.get('/locations?deviceId={}'.format(deviceid), headers=settings.header)
         self.assertEqual(rv.status_code, 200)
-        actual_loc_id = json.loads(rv.data.decode('utf-8'))['id']
-        self.assertEqual(actual_loc_id, expected_loc_id)
+        actual_json_response = json.loads(rv.data.decode('utf-8'))
+        self.assertTrue(expected_loc_id in actual_json_response)
+        actual_loc_id = actual_json_response[expected_loc_id]['id']
+        self.assertEqual(actual_loc_id, int(expected_loc_id))


### PR DESCRIPTION
The purpose of this PR is to unify access to locations api.
Location by deviceId has been moved to `locations.py` and added as a optional filtering parameter of `/locations` endpoint:
e.g. `/locations?deviceId=<device_id>`.

This change is connected with another PR to meerkat_mad config repo.