### PR TITLE
Start date for indicators in one year back instead of start of epi_year.

### DIFF
--- a/meerkat_api/resources/indicators.py
+++ b/meerkat_api/resources/indicators.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from dateutil.relativedelta import relativedelta
 from flask_restful import Resource
 from sqlalchemy import or_, Float
 from meerkat_api.extensions import db, api
@@ -32,10 +33,9 @@ class Indicators(Resource):
 
     def get(self, flags, variables, location, start_date=None, end_date=None):
 
-        # If no start date given, we should default to start of the epi year.
         if not start_date:
-            this_year = datetime.datetime.now().year
-            start_date = ew.epi_year_start_date_by_year(this_year).isoformat()
+            one_year_ago = datetime.datetime.now() - relativedelta(years=1)
+            start_date = one_year_ago.isoformat()
 
         s = time.time()
         mult_factor = 1


### PR DESCRIPTION
After speaking with Gunnar we've decided that having the start date exactly 52 epi weeks ago is not that important. Setting it up to one year back is good enough and we avoid handling epi_week 53/0 and get simpler code.