### PR TITLE
None value for field key download fix.

### DIFF
--- a/api_background/api_background/export_data.py
+++ b/api_background/api_background/export_data.py
@@ -516,13 +516,12 @@ def export_category(uuid, form_name, category, download_name,
             elif "$to_columns$" in form_var:
                 field = form_var.split("$")[0]
                 codes = form_var.split("$")[-1].split(",")
-                has_code = 0
-                data = raw_data.get(field, "").split(" ")
-                for c in codes:
-                    if c in data:
-                        has_code = 1
-                        break
-                list_row[index] = has_code
+                int_has_code = 0
+                if field in raw_data:
+                    elements = raw_data[field].split(" ")
+                    has_code = any(code in elements for code in codes)
+                    int_has_code = int(has_code)
+                list_row[index] = int_has_code
             else:
                 if form_var.split("$")[0] in raw_data:
                     list_row[index] = raw_data[form_var.split("$")[0]]


### PR DESCRIPTION
The main change here is that sometimes `raw_data[field]` may return a `None` value which breaks the rest of our code.
My solution here is to bypass checking code inclusion in this case and simply assign has_code as 0.